### PR TITLE
Serverless transform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,8 @@ SIDECAR_SECRET_ACCESS_KEY=
 SIDECAR_REGION=
 SIDECAR_ARTIFACT_BUCKET_NAME=
 SIDECAR_EXECUTION_ROLE=
+
+# Serverless transform runner (optional). When set, enables the Transform tab on plugin recipe pages.
+# Point to a running instance of the transform-runner microservice.
+TRANSFORM_RUNNER_URL=
+TRANSFORM_TIMEOUT_SECONDS=30

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -15,6 +15,7 @@ use App\Liquid\Tags\TemplateTag;
 use App\Plugins\PluginHandler;
 use App\Plugins\PluginRegistry;
 use App\Services\Plugin\Parsers\ResponseParserRegistry;
+use App\Services\Plugin\ServerlessTransformService;
 use App\Services\PluginImportService;
 use Carbon\Carbon;
 use Closure;
@@ -55,6 +56,8 @@ class Plugin extends Model
         'plugin_type' => 'string',
         'alias' => 'boolean',
         'current_image_metadata' => 'array',
+        'transform_code'         => 'string',   // add this
+        'transform_language'     => 'string',   // add this
     ];
 
     protected static function boot()
@@ -513,6 +516,11 @@ class Plugin extends Model
         if (! self::dataPayloadWithinWireLimit($finalPayload)) {
             Log::warning("Plugin {$this->id} data_payload exceeded wire size limit; storing error placeholder");
             $finalPayload = self::oversizedDataPayloadErrorPayload();
+        }
+
+        if ($this->transform_code && $this->transform_language) {
+            $finalPayload = app(ServerlessTransformService::class)
+                ->run($this->transform_code, $this->transform_language, $finalPayload);
         }
 
         $this->update([

--- a/app/Services/Plugin/ServerlessTransformService.php
+++ b/app/Services/Plugin/ServerlessTransformService.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Services\Plugin;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Process;
+
+class ServerlessTransformService
+{
+    private const DEFAULT_TIMEOUT = 30;
+
+    private const INTERPRETERS = [
+        'python' => 'python3',
+        'node'   => 'node',
+        'php'    => 'php',
+    ];
+
+    private const EXTENSIONS = [
+        'python' => 'py',
+        'node'   => 'js',
+        'php'    => 'php',
+    ];
+
+    public function run(string $code, string $language, array $input, ?int $timeout = null): array
+    {
+        if (! array_key_exists($language, self::INTERPRETERS)) {
+            Log::warning("ServerlessTransformService: unsupported language [{$language}]");
+
+            return $input;
+        }
+
+        $effectiveTimeout = $timeout ?? (int) env('TRANSFORM_TIMEOUT_SECONDS', self::DEFAULT_TIMEOUT);
+        $tmpDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'trmnl-tx-'.bin2hex(random_bytes(8));
+        mkdir($tmpDir, 0700, true);
+
+        $scriptPath = $tmpDir.DIRECTORY_SEPARATOR.'transform.'.self::EXTENSIONS[$language];
+        $outputPath = $tmpDir.DIRECTORY_SEPARATOR.'output.json';
+
+        try {
+            file_put_contents($scriptPath, $this->buildHarness($language, $code, $outputPath));
+
+            $result = Process::input(json_encode($input))
+                ->timeout($effectiveTimeout)
+                ->run([self::INTERPRETERS[$language], $scriptPath]);
+
+            if (! $result->successful()) {
+                Log::warning('ServerlessTransformService: transform exited '.$result->exitCode().': '.trim($result->errorOutput()));
+
+                return $input;
+            }
+
+            if (! file_exists($outputPath)) {
+                Log::warning('ServerlessTransformService: transform produced no output file');
+
+                return $input;
+            }
+
+            $raw = file_get_contents($outputPath);
+            if ($raw === false || $raw === '') {
+                Log::warning('ServerlessTransformService: transform output file is empty');
+
+                return $input;
+            }
+
+            $decoded = json_decode($raw, true);
+            if (! is_array($decoded)) {
+                Log::warning('ServerlessTransformService: transform output is not a JSON object');
+
+                return $input;
+            }
+
+            return $decoded;
+        } catch (\Throwable $e) {
+            Log::warning('ServerlessTransformService: '.$e->getMessage());
+
+            return $input;
+        } finally {
+            $this->cleanupDir($tmpDir);
+        }
+    }
+
+    private function buildHarness(string $language, string $code, string $outputPath): string
+    {
+        return match ($language) {
+            'python' => $this->pythonHarness($code, $outputPath),
+            'node'   => $this->nodeHarness($code, $outputPath),
+            'php'    => $this->phpHarness($code, $outputPath),
+        };
+    }
+
+    private function pythonHarness(string $code, string $outputPath): string
+    {
+        $path = var_export($outputPath, true);
+
+        return implode("\n", [
+            'import sys, json',
+            'input = json.loads(sys.stdin.read())',
+            '',
+            $code,
+            '',
+            "if callable(locals().get('run', None)):",
+            '    output = run(input)',
+            "elif 'result' in dir():",
+            '    output = result',
+            'else:',
+            '    output = input',
+            "json.dump(output, open({$path}, 'w'))",
+        ]);
+    }
+
+    private function nodeHarness(string $code, string $outputPath): string
+    {
+        $path = json_encode($outputPath);
+
+        return "const input = JSON.parse(require('fs').readFileSync(0, 'utf8'));\n\n"
+            .$code
+            ."\n\nlet output;\n"
+            ."if (typeof run === 'function') {\n  output = run(input);\n"
+            ."} else if (typeof result !== 'undefined') {\n  output = result;\n"
+            ."} else {\n  output = input;\n}\n"
+            ."require('fs').writeFileSync({$path}, JSON.stringify(output));\n";
+    }
+
+    private function phpHarness(string $code, string $outputPath): string
+    {
+        $cleanedCode = preg_replace('/\A\s*<\?php\s*/u', '', $code);
+        $path = var_export($outputPath, true);
+
+        return "<?php\n"
+            ."\$input = json_decode(file_get_contents('php://stdin'), true);\n\n"
+            .$cleanedCode
+            ."\n\nif (function_exists('run')) {\n    \$output = run(\$input);\n"
+            ."} elseif (isset(\$result)) {\n    \$output = \$result;\n"
+            ."} else {\n    \$output = \$input;\n}\n"
+            ."file_put_contents({$path}, json_encode(\$output));\n";
+    }
+
+    private function cleanupDir(string $dir): void
+    {
+        if (! is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir.DIRECTORY_SEPARATOR.'*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($dir);
+    }
+}

--- a/app/Services/Plugin/ServerlessTransformService.php
+++ b/app/Services/Plugin/ServerlessTransformService.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Log;
 
 class ServerlessTransformService
 {
-    public function run(string $code, string $language, array $input): array
+    public function run(string $code, string $language, array $input, bool $strict = false): array
     {
         $url = config('services.transform_runner.url');
         if (! $url) {
@@ -25,24 +25,32 @@ class ServerlessTransformService
             ]);
 
             if (! $response->successful()) {
-                Log::warning('ServerlessTransformService: runner returned '.$response->status().': '.$response->json('error', ''));
-
-                return $input;
+                return $this->fail(
+                    'ServerlessTransformService: runner returned '.$response->status().': '.$response->json('error', ''),
+                    $input,
+                    $strict
+                );
             }
 
             $output = $response->json('output');
             if (! is_array($output)) {
-                Log::warning('ServerlessTransformService: runner output is not a JSON object');
-
-                return $input;
+                return $this->fail('ServerlessTransformService: runner output is not a JSON object', $input, $strict);
             }
 
             return $output;
         } catch (\Throwable $e) {
-            Log::warning('ServerlessTransformService: '.$e->getMessage());
-
-            return $input;
+            return $this->fail('ServerlessTransformService: '.$e->getMessage(), $input, $strict);
         }
+    }
+
+    private function fail(string $message, array $input, bool $strict): array
+    {
+        if ($strict) {
+            throw new \RuntimeException($message);
+        }
+        Log::warning($message);
+
+        return $input;
     }
 
     public function isEnabled(): bool

--- a/app/Services/Plugin/ServerlessTransformService.php
+++ b/app/Services/Plugin/ServerlessTransformService.php
@@ -2,147 +2,51 @@
 
 namespace App\Services\Plugin;
 
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Process;
 
 class ServerlessTransformService
 {
-    private const DEFAULT_TIMEOUT = 30;
-
-    private const INTERPRETERS = [
-        'python' => 'python3',
-        'node'   => 'node',
-        'php'    => 'php',
-    ];
-
-    private const EXTENSIONS = [
-        'python' => 'py',
-        'node'   => 'js',
-        'php'    => 'php',
-    ];
-
-    public function run(string $code, string $language, array $input, ?int $timeout = null): array
+    public function run(string $code, string $language, array $input): array
     {
-        if (! array_key_exists($language, self::INTERPRETERS)) {
-            Log::warning("ServerlessTransformService: unsupported language [{$language}]");
-
+        $url = config('services.transform_runner.url');
+        if (! $url) {
             return $input;
         }
 
-        $effectiveTimeout = $timeout ?? (int) env('TRANSFORM_TIMEOUT_SECONDS', self::DEFAULT_TIMEOUT);
-        $tmpDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'trmnl-tx-'.bin2hex(random_bytes(8));
-        mkdir($tmpDir, 0700, true);
-
-        $scriptPath = $tmpDir.DIRECTORY_SEPARATOR.'transform.'.self::EXTENSIONS[$language];
-        $outputPath = $tmpDir.DIRECTORY_SEPARATOR.'output.json';
+        $timeout = config('services.transform_runner.timeout', 30);
 
         try {
-            file_put_contents($scriptPath, $this->buildHarness($language, $code, $outputPath));
+            $response = Http::timeout($timeout)->post("{$url}/run", [
+                'language' => $language,
+                'code'     => $code,
+                'input'    => $input,
+                'timeout'  => $timeout,
+            ]);
 
-            $result = Process::input(json_encode($input))
-                ->timeout($effectiveTimeout)
-                ->run([self::INTERPRETERS[$language], $scriptPath]);
-
-            if (! $result->successful()) {
-                Log::warning('ServerlessTransformService: transform exited '.$result->exitCode().': '.trim($result->errorOutput()));
-
-                return $input;
-            }
-
-            if (! file_exists($outputPath)) {
-                Log::warning('ServerlessTransformService: transform produced no output file');
+            if (! $response->successful()) {
+                Log::warning('ServerlessTransformService: runner returned '.$response->status().': '.$response->json('error', ''));
 
                 return $input;
             }
 
-            $raw = file_get_contents($outputPath);
-            if ($raw === false || $raw === '') {
-                Log::warning('ServerlessTransformService: transform output file is empty');
+            $output = $response->json('output');
+            if (! is_array($output)) {
+                Log::warning('ServerlessTransformService: runner output is not a JSON object');
 
                 return $input;
             }
 
-            $decoded = json_decode($raw, true);
-            if (! is_array($decoded)) {
-                Log::warning('ServerlessTransformService: transform output is not a JSON object');
-
-                return $input;
-            }
-
-            return $decoded;
+            return $output;
         } catch (\Throwable $e) {
             Log::warning('ServerlessTransformService: '.$e->getMessage());
 
             return $input;
-        } finally {
-            $this->cleanupDir($tmpDir);
         }
     }
 
-    private function buildHarness(string $language, string $code, string $outputPath): string
+    public function isEnabled(): bool
     {
-        return match ($language) {
-            'python' => $this->pythonHarness($code, $outputPath),
-            'node'   => $this->nodeHarness($code, $outputPath),
-            'php'    => $this->phpHarness($code, $outputPath),
-        };
-    }
-
-    private function pythonHarness(string $code, string $outputPath): string
-    {
-        $path = var_export($outputPath, true);
-
-        return implode("\n", [
-            'import sys, json',
-            'input = json.loads(sys.stdin.read())',
-            '',
-            $code,
-            '',
-            "if callable(locals().get('run', None)):",
-            '    output = run(input)',
-            "elif 'result' in dir():",
-            '    output = result',
-            'else:',
-            '    output = input',
-            "json.dump(output, open({$path}, 'w'))",
-        ]);
-    }
-
-    private function nodeHarness(string $code, string $outputPath): string
-    {
-        $path = json_encode($outputPath);
-
-        return "const input = JSON.parse(require('fs').readFileSync(0, 'utf8'));\n\n"
-            .$code
-            ."\n\nlet output;\n"
-            ."if (typeof run === 'function') {\n  output = run(input);\n"
-            ."} else if (typeof result !== 'undefined') {\n  output = result;\n"
-            ."} else {\n  output = input;\n}\n"
-            ."require('fs').writeFileSync({$path}, JSON.stringify(output));\n";
-    }
-
-    private function phpHarness(string $code, string $outputPath): string
-    {
-        $cleanedCode = preg_replace('/\A\s*<\?php\s*/u', '', $code);
-        $path = var_export($outputPath, true);
-
-        return "<?php\n"
-            ."\$input = json_decode(file_get_contents('php://stdin'), true);\n\n"
-            .$cleanedCode
-            ."\n\nif (function_exists('run')) {\n    \$output = run(\$input);\n"
-            ."} elseif (isset(\$result)) {\n    \$output = \$result;\n"
-            ."} else {\n    \$output = \$input;\n}\n"
-            ."file_put_contents({$path}, json_encode(\$output));\n";
-    }
-
-    private function cleanupDir(string $dir): void
-    {
-        if (! is_dir($dir)) {
-            return;
-        }
-        foreach (glob($dir.DIRECTORY_SEPARATOR.'*') ?: [] as $file) {
-            @unlink($file);
-        }
-        @rmdir($dir);
+        return (bool) config('services.transform_runner.url');
     }
 }

--- a/app/Services/Plugin/ServerlessTransformService.php
+++ b/app/Services/Plugin/ServerlessTransformService.php
@@ -25,21 +25,38 @@ class ServerlessTransformService
             ]);
 
             if (! $response->successful()) {
-                return $this->fail(
-                    'ServerlessTransformService: runner returned '.$response->status().': '.$response->json('error', ''),
-                    $input,
-                    $strict
-                );
+                $msg = 'runner returned '.$response->status().': '.$response->json('error', $response->body());
+                if ($strict) {
+                    throw new \RuntimeException($msg);
+                }
+                Log::warning('ServerlessTransformService: '.$msg);
+
+                return ['error' => $msg];
             }
 
             $output = $response->json('output');
-            if (! is_array($output)) {
-                return $this->fail('ServerlessTransformService: runner output is not a JSON object', $input, $strict);
+            if (is_array($output)) {
+                return $output;
             }
 
-            return $output;
+            // Runner returned an error body (e.g. {"error": "..."}) — store it as the payload.
+            $runnerBody = $response->json();
+            if (is_array($runnerBody)) {
+                if ($strict) {
+                    throw new \RuntimeException($runnerBody['error'] ?? 'transform runner returned no output');
+                }
+
+                return $runnerBody;
+            }
+
+            return $this->fail('ServerlessTransformService: runner returned no output', $input, $strict);
         } catch (\Throwable $e) {
-            return $this->fail('ServerlessTransformService: '.$e->getMessage(), $input, $strict);
+            if ($strict) {
+                throw new \RuntimeException('ServerlessTransformService: '.$e->getMessage(), previous: $e);
+            }
+            Log::warning('ServerlessTransformService: '.$e->getMessage());
+
+            return ['error' => $e->getMessage()];
         }
     }
 

--- a/app/Services/PluginImportService.php
+++ b/app/Services/PluginImportService.php
@@ -644,6 +644,13 @@ class PluginImportService
                         $quadrantLiquidPath = $newSrcDir.'/quadrant.'.$extension;
                     }
 
+                    foreach (['py', 'js', 'php'] as $transformExt) {
+                        $origTransformPath = $srcDir.'/transform.'.$transformExt;
+                        if (File::exists($origTransformPath)) {
+                            File::copy($origTransformPath, $newSrcDir.'/transform.'.$transformExt);
+                        }
+                    }
+
                     // Update the paths
                     $settingsYamlPath = $newSrcDir.'/settings.yml';
                 }

--- a/app/Services/PluginImportService.php
+++ b/app/Services/PluginImportService.php
@@ -90,6 +90,23 @@ class PluginImportService
         $settings = Yaml::parse(count($yamlParts) > 1 ? $yamlParts[1] : $settingsYaml);
         $this->validateYAML($settings);
 
+        $transformCode = null;
+        $transformLanguage = null;
+        $serverlessLanguage = ! empty($settings['serverless_language'])
+            ? strtolower((string) $settings['serverless_language'])
+            : null;
+
+        if ($serverlessLanguage) {
+            $extMap = ['python' => 'py', 'node' => 'js', 'php' => 'php'];
+            $ext = $extMap[$serverlessLanguage] ?? null;
+            $srcDir = dirname((string) $filePaths['settingsYamlPath']);
+
+            if ($ext && File::exists($srcDir.'/transform.'.$ext)) {
+                $transformCode = File::get($srcDir.'/transform.'.$ext);
+                $transformLanguage = $serverlessLanguage;
+            }
+        }
+
         // Determine markup language from the first available file
         $markupLanguage = 'blade';
         $firstTemplatePath = $filePaths['fullLiquidPath']
@@ -185,6 +202,8 @@ class PluginImportService
                 'configuration_template' => $configurationTemplate,
                 'data_payload' => json_decode($settings['static_data'] ?? '{}', true),
                 'framework_version' => $settings['framework_version'] ?? null,
+                'transform_code'     => $transformCode,
+                'transform_language' => $transformLanguage,
             ]);
 
         if (! $plugin_updated) {
@@ -259,6 +278,23 @@ class PluginImportService
         $yamlParts = preg_split('/^---[ \t]*\r?\n/m', $settingsYaml, 2);
         $settings = Yaml::parse(count($yamlParts) > 1 ? $yamlParts[1] : $settingsYaml);
         $this->validateYAML($settings);
+
+        $transformCode = null;
+        $transformLanguage = null;
+        $serverlessLanguage = ! empty($settings['serverless_language'])
+            ? strtolower((string) $settings['serverless_language'])
+            : null;
+
+        if ($serverlessLanguage) {
+            $extMap = ['python' => 'py', 'node' => 'js', 'php' => 'php'];
+            $ext = $extMap[$serverlessLanguage] ?? null;
+            $srcDir = dirname((string) $filePaths['settingsYamlPath']);
+
+            if ($ext && File::exists($srcDir.'/transform.'.$ext)) {
+                $transformCode = File::get($srcDir.'/transform.'.$ext);
+                $transformLanguage = $serverlessLanguage;
+            }
+        }
 
         // Determine markup language from the first available file
         $markupLanguage = 'blade';
@@ -367,6 +403,8 @@ class PluginImportService
                 'preferred_renderer' => $preferredRenderer,
                 'framework_version' => $settings['framework_version'] ?? null,
                 'icon_url' => $iconUrl,
+                'transform_code'     => $transformCode,
+                'transform_language' => $transformLanguage,
             ]);
 
         if (! $plugin_updated) {

--- a/config/services.php
+++ b/config/services.php
@@ -65,4 +65,9 @@ return [
         'scopes' => explode(',', env('OIDC_SCOPES', 'openid,profile,email')),
     ],
 
+    'transform_runner' => [
+        'url'     => env('TRANSFORM_RUNNER_URL'),
+        'timeout' => (int) env('TRANSFORM_TIMEOUT_SECONDS', 30),
+    ],
+
 ];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,22 @@ services:
             - PHP_OPCACHE_ENABLE=1
             - TRMNL_PROXY_REFRESH_MINUTES=15
             - DB_DATABASE=database/storage/database.sqlite
+            - TRANSFORM_RUNNER_URL=http://transform-runner:3000
         volumes:
            - database:/var/www/html/database/storage
            - storage:/var/www/html/storage/app/public/images/generated
         restart: unless-stopped
+        depends_on:
+            - transform-runner
         #platform: "linux/arm64/v8"
+
+    transform-runner:
+        build:
+            context: ./runner
+            dockerfile: Dockerfile
+        restart: unless-stopped
+        #platform: "linux/arm64/v8"
+
 volumes:
     database:
     storage:
-

--- a/docs/docs/getting-started/environment-variables.md
+++ b/docs/docs/getting-started/environment-variables.md
@@ -17,3 +17,5 @@ description: LaraPaper environment configuration reference.
 | `PHP_OPCACHE_ENABLE` | Enable PHP OPcache | `0` |
 | `TRMNL_IMAGE_URL_TIMEOUT` | Display endpoint response timeout (seconds) | `30` |
 | `APP_TIMEZONE` | PHP timezone (UTC recommended) | `UTC` |
+| `TRANSFORM_RUNNER_URL` | Base URL of the transform runner microservice (e.g. `http://localhost:3000`). When set, enables the Transform tab on plugin recipe pages. Omit to disable the feature. | — |
+| `TRANSFORM_TIMEOUT_SECONDS` | HTTP timeout for transform runner requests (seconds) | `30` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "larapaper",
             "dependencies": {
                 "@codemirror/commands": "^6.9.0",
                 "@codemirror/lang-css": "^6.3.1",
@@ -12,6 +11,8 @@
                 "@codemirror/lang-javascript": "^6.2.4",
                 "@codemirror/lang-json": "^6.0.2",
                 "@codemirror/lang-liquid": "^6.3.0",
+                "@codemirror/lang-php": "^6.0.2",
+                "@codemirror/lang-python": "^6.2.1",
                 "@codemirror/lang-yaml": "^6.1.2",
                 "@codemirror/language": "^6.11.3",
                 "@codemirror/search": "^6.5.11",
@@ -151,6 +152,32 @@
                 "@lezer/common": "^1.0.0",
                 "@lezer/highlight": "^1.0.0",
                 "@lezer/lr": "^1.3.1"
+            }
+        },
+        "node_modules/@codemirror/lang-php": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+            "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/lang-html": "^6.0.0",
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@lezer/common": "^1.0.0",
+                "@lezer/php": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/lang-python": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+            "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/autocomplete": "^6.3.2",
+                "@codemirror/language": "^6.8.0",
+                "@codemirror/state": "^6.0.0",
+                "@lezer/common": "^1.2.1",
+                "@lezer/python": "^1.1.4"
             }
         },
         "node_modules/@codemirror/lang-yaml": {
@@ -419,6 +446,28 @@
             "license": "MIT",
             "dependencies": {
                 "@lezer/common": "^1.0.0"
+            }
+        },
+        "node_modules/@lezer/php": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
+            "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.2.0",
+                "@lezer/highlight": "^1.0.0",
+                "@lezer/lr": "^1.1.0"
+            }
+        },
+        "node_modules/@lezer/python": {
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.19.tgz",
+            "integrity": "sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.2.0",
+                "@lezer/highlight": "^1.0.0",
+                "@lezer/lr": "^1.0.0"
             }
         },
         "node_modules/@lezer/yaml": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
         "@codemirror/lang-javascript": "^6.2.4",
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-liquid": "^6.3.0",
+        "@codemirror/lang-php": "^6.0.2",
+        "@codemirror/lang-python": "^6.2.1",
         "@codemirror/lang-yaml": "^6.1.2",
         "@codemirror/language": "^6.11.3",
         "@codemirror/search": "^6.5.11",

--- a/resources/js/codemirror-core.js
+++ b/resources/js/codemirror-core.js
@@ -10,6 +10,8 @@ import { json } from '@codemirror/lang-json';
 import { css } from '@codemirror/lang-css';
 import { liquid } from '@codemirror/lang-liquid';
 import { yaml } from '@codemirror/lang-yaml';
+import { python } from '@codemirror/lang-python';
+import { php } from '@codemirror/lang-php';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { githubLight } from '@fsegurai/codemirror-theme-github-light';
 
@@ -23,6 +25,9 @@ const LANGUAGE_MAP = {
     'html': html,
     'yaml': yaml,
     'yml': yaml,
+    'python': python,
+    'py': python,
+    'php': php,
 };
 
 // Theme support mapping

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 new class extends Component
 {
+    use \Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
     public Plugin $plugin;
 
     public ?string $markup_code;
@@ -81,9 +83,27 @@ new class extends Component
 
     public ?string $transform_run_output = null;
 
+    public bool $is_shared = false;
+
+    public function getAvailableUsersProperty(): \Illuminate\Database\Eloquent\Collection
+    {
+        return \App\Models\User::whereNotNull('confirmed_at')->orderBy('name')->get();
+    }
+
+    public function reassignPlugin(int $newOwnerId): void
+    {
+        $this->authorize('reassign', $this->plugin);
+
+        $newOwner = \App\Models\User::findOrFail($newOwnerId);
+        $this->plugin->update(['user_id' => $newOwner->id]);
+        $this->plugin = $this->plugin->fresh();
+
+        Flux::toast(variant: 'success', text: 'Plugin ownership updated.');
+    }
+
     public function mount(): void
     {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
         $this->blade_code = $this->plugin->render_markup;
         // required to render some stuff
         $this->configuration_template = $this->plugin->configuration_template ?? [];
@@ -157,6 +177,17 @@ new class extends Component
         $this->polling_header = $this->plugin->polling_header;
         $this->polling_body = $this->plugin->polling_body;
         $this->data_payload = json_encode($this->plugin->data_payload, JSON_PRETTY_PRINT);
+        $this->is_shared = (bool) $this->plugin->is_shared;
+    }
+
+    public function toggleShared(): void
+    {
+        $this->authorize('share', $this->plugin);
+
+        $this->plugin->update(['is_shared' => ! $this->plugin->is_shared]);
+        $this->is_shared = (bool) $this->plugin->fresh()->is_shared;
+
+        Flux::toast(variant: 'success', text: $this->is_shared ? 'Plugin shared.' : 'Plugin unshared.');
     }
 
     public function saveMarkup(): void
@@ -207,13 +238,22 @@ new class extends Component
 
     public function switchTab(string $layout): void
     {
-        if (in_array($layout, $this->active_tabs, true)) {
-            // Save current tab's content before switching
-            if (isset($this->markup_layouts[$this->active_tab])) {
-                $this->markup_layouts[$this->active_tab] = $this->markup_code ?? '';
-            }
+        $isMarkupTab = in_array($layout, $this->active_tabs, true);
+        $isTransformTab = $layout === 'transform'
+            && $this->transform_code !== null
+            && app(ServerlessTransformService::class)->isEnabled();
 
-            $this->active_tab = $layout;
+        if (! $isMarkupTab && ! $isTransformTab) {
+            return;
+        }
+
+        // Save outgoing markup tab content (not when leaving the transform tab)
+        if ($this->active_tab !== 'transform' && isset($this->markup_layouts[$this->active_tab])) {
+            $this->markup_layouts[$this->active_tab] = $this->markup_code ?? '';
+        }
+
+        $this->active_tab = $layout;
+        if ($layout !== 'transform') {
             $this->markup_code = $this->markup_layouts[$layout] ?? '';
         }
     }
@@ -249,6 +289,7 @@ new class extends Component
             'half_vertical' => 'Half Vertical',
             'quadrant' => 'Quadrant',
             'shared' => 'Shared',
+            'transform' => 'Transform',
             default => ucfirst($layout),
         };
     }
@@ -538,14 +579,6 @@ HTML;
 
         try {
             $device = $this->createPreviewDevice();
-
-            if ($this->transform_run_output !== null) {
-                $decoded = json_decode($this->transform_run_output, true);
-                if (is_array($decoded)) {
-                    $this->plugin->data_payload = $decoded;
-                }
-            }
-
             $previewMarkup = $this->plugin->render($size, true, $device);
             $dimensions = $this->previewScreenDimensionsForDevice($device);
             $this->dispatch(
@@ -604,14 +637,6 @@ HTML;
 
         try {
             $device = $this->createPreviewDevice();
-
-            if ($this->transform_run_output !== null) {
-                $decoded = json_decode($this->transform_run_output, true);
-                if (is_array($decoded)) {
-                    $this->plugin->data_payload = $decoded;
-                }
-            }
-
             $markup = $this->plugin->render($this->preview_size, true, $device);
 
             $imageUuid = App\Services\ImageGenerationService::generateImageFromModel(
@@ -717,21 +742,49 @@ HTML;
         $this->redirect(route('plugins.index'));
     }
 
-    public function addTransform(): void
+    public function enableTransform(): void
     {
-        $this->transform_code = '';
-        $this->transform_language = 'python';
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
+        if ($this->transform_code === null) {
+            $this->transform_code = '';
+            $this->transform_language ??= 'python';
+            $this->plugin->update([
+                'transform_code'     => '',
+                'transform_language' => $this->transform_language,
+            ]);
+        }
+    }
+
+    public function disableTransform(): void
+    {
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
+        $this->transform_code = null;
+        $this->transform_run_output = null;
+        $this->plugin->update(['transform_code' => null, 'transform_language' => null]);
+        if ($this->active_tab === 'transform') {
+            $this->active_tab = 'full';
+            $this->markup_code = $this->markup_layouts['full'] ?? '';
+        }
+    }
+
+    public function updatedTransformLanguage(): void
+    {
+        if ($this->transform_code !== null) {
+            $this->plugin->update(['transform_language' => $this->transform_language]);
+        }
     }
 
     public function saveTransform(): void
     {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
         $this->validate(['transform_code' => 'nullable|string', 'transform_language' => 'nullable|string|in:python,node,php']);
 
         $this->plugin->update([
-            'transform_code'     => $this->transform_code ?: null,
-            'transform_language' => $this->transform_code ? $this->transform_language : null,
+            'transform_code'     => $this->transform_code,
+            'transform_language' => $this->transform_language,
         ]);
+
+        Flux::toast(variant: 'success', text: 'Transform saved.');
     }
 
     public function runTransform(): void
@@ -801,55 +854,62 @@ HTML;
     "
 >
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-        <div class="flex justify-between items-center mb-6">
+        <div class="flex justify-between items-center mb-3">
             <h2 class="text-2xl font-semibold dark:text-gray-100">{{$plugin->name}}
                 <flux:badge size="sm" class="ml-2">Recipe</flux:badge>
             </h2>
 
-            <flux:button.group>
-                <flux:modal.trigger name="preview-plugin">
-                    <flux:button icon="eye" wire:click="renderPreview" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Preview</flux:button>
-                </flux:modal.trigger>
-                <flux:dropdown>
-                    <flux:button icon="chevron-down" :disabled="$plugin->hasMissingRequiredConfigurationFields()"></flux:button>
-                    <flux:menu>
-                        <flux:modal.trigger name="preview-plugin">
-                            <flux:menu.item icon="mashup-1Tx1B" wire:click="renderPreview('half_horizontal')" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Half-Horizontal
-                            </flux:menu.item>
-                        </flux:modal.trigger>
+            <div class="flex items-center gap-3">
+                @if($plugin->user_id === auth()->id() || auth()->user()->isAdmin())
+                    <flux:switch wire:click="toggleShared" :checked="$is_shared" label="Shared"/>
+                @endif
 
-                        <flux:modal.trigger name="preview-plugin">
-                            <flux:menu.item icon="mashup-1Lx1R" wire:click="renderPreview('half_vertical')" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Half-Vertical
-                            </flux:menu.item>
-                        </flux:modal.trigger>
+                <flux:button.group>
+                    <flux:modal.trigger name="preview-plugin">
+                        <flux:button icon="eye" wire:click="renderPreview" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Preview</flux:button>
+                    </flux:modal.trigger>
+                    <flux:dropdown>
+                        <flux:button icon="chevron-down" :disabled="$plugin->hasMissingRequiredConfigurationFields()"></flux:button>
+                        <flux:menu>
+                            <flux:modal.trigger name="preview-plugin">
+                                <flux:menu.item icon="mashup-1Tx1B" wire:click="renderPreview('half_horizontal')" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Half-Horizontal
+                                </flux:menu.item>
+                            </flux:modal.trigger>
 
-                        <flux:modal.trigger name="preview-plugin">
-                            <flux:menu.item icon="mashup-2x2" wire:click="renderPreview('quadrant')" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Quadrant</flux:menu.item>
-                        </flux:modal.trigger>
-                    </flux:menu>
-                </flux:dropdown>
-            </flux:button.group>
-            <flux:button.group>
-                <flux:modal.trigger name="add-to-playlist">
-                    <flux:button icon="play" variant="primary" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Add to Playlist</flux:button>
-                </flux:modal.trigger>
+                            <flux:modal.trigger name="preview-plugin">
+                                <flux:menu.item icon="mashup-1Lx1R" wire:click="renderPreview('half_vertical')" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Half-Vertical
+                                </flux:menu.item>
+                            </flux:modal.trigger>
 
-                <flux:dropdown>
-                    <flux:button icon="chevron-down" variant="primary"></flux:button>
-                    <flux:menu>
-                        <flux:modal.trigger name="trmnlp-settings">
-                            <flux:menu.item icon="cog">Recipe Settings</flux:menu.item>
-                        </flux:modal.trigger>
-                        <flux:menu.separator />
-                        <flux:menu.item icon="document-duplicate" wire:click="duplicatePlugin">Duplicate Plugin</flux:menu.item>
-                        <flux:modal.trigger name="delete-plugin">
-                            <flux:menu.item icon="trash" variant="danger">Delete Plugin</flux:menu.item>
-                        </flux:modal.trigger>
-                        <flux:menu.separator />
-                        <flux:menu.item icon="archive-box" wire:click="exportPluginArchive">Export Recipe Archive</flux:menu.item>
-                    </flux:menu>
-                </flux:dropdown>
-            </flux:button.group>
+                            <flux:modal.trigger name="preview-plugin">
+                                <flux:menu.item icon="mashup-2x2" wire:click="renderPreview('quadrant')" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Quadrant</flux:menu.item>
+                            </flux:modal.trigger>
+                        </flux:menu>
+                    </flux:dropdown>
+                </flux:button.group>
+
+                <flux:button.group>
+                    <flux:modal.trigger name="add-to-playlist">
+                        <flux:button icon="play" variant="primary" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Add to Playlist</flux:button>
+                    </flux:modal.trigger>
+
+                    <flux:dropdown>
+                        <flux:button icon="chevron-down" variant="primary"></flux:button>
+                        <flux:menu>
+                            <flux:modal.trigger name="trmnlp-settings">
+                                <flux:menu.item icon="cog">Recipe Settings</flux:menu.item>
+                            </flux:modal.trigger>
+                            <flux:menu.separator />
+                            <flux:menu.item icon="document-duplicate" wire:click="duplicatePlugin">Duplicate Plugin</flux:menu.item>
+                            <flux:modal.trigger name="delete-plugin">
+                                <flux:menu.item icon="trash" variant="danger">Delete Plugin</flux:menu.item>
+                            </flux:modal.trigger>
+                            <flux:menu.separator />
+                            <flux:menu.item icon="archive-box" wire:click="exportPluginArchive">Export Recipe Archive</flux:menu.item>
+                        </flux:menu>
+                    </flux:dropdown>
+                </flux:button.group>
+            </div>
         </div>
 
         <flux:modal name="add-to-playlist" class="min-w-2xl">
@@ -1071,6 +1131,18 @@ HTML;
                                     name="name" autofocus/>
                     </div>
 
+                    @if(auth()->user()->isAdmin())
+                        <div class="mb-4">
+                            <flux:select label="Owner" wire:change="reassignPlugin($event.target.value)">
+                                @foreach ($this->availableUsers as $u)
+                                    <flux:select.option value="{{ $u->id }}" :selected="$plugin->user_id === $u->id">
+                                        {{ $u->name }}
+                                    </flux:select.option>
+                                @endforeach
+                            </flux:select>
+                        </div>
+                    @endif
+
                     @php
                         $authorField = null;
                         if (isset($configuration_template['custom_fields'])) {
@@ -1161,8 +1233,17 @@ HTML;
                     @if($data_strategy === 'polling')
                     <flux:label>Polling URL</flux:label>
 
-                    <div x-data="{ subTab: 'settings' }" class="mt-2 mb-4">
+                    <div x-data="{ subTab: 'urls' }" class="mt-2 mb-4">
                         <div class="flex">
+                            <button
+                                @click="subTab = 'urls'"
+                                class="tab-button"
+                                :class="subTab === 'urls' ? 'is-active' : ''"
+                            >
+                                <flux:icon.link class="size-4"/>
+                                URLs
+                            </button>
+
                             <button
                                 @click="subTab = 'settings'"
                                 class="tab-button"
@@ -1172,18 +1253,21 @@ HTML;
                                 Settings
                             </button>
 
+                            @if(app(ServerlessTransformService::class)->isEnabled())
                             <button
-                                @click="subTab = 'preview'"
+                                @click="subTab = 'transform'"
                                 class="tab-button"
-                                :class="subTab === 'preview' ? 'is-active' : ''"
+                                :class="subTab === 'transform' ? 'is-active' : ''"
                             >
-                                <flux:icon.eye class="size-4" />
-                                Preview URL
+                                <flux:icon.code-bracket class="size-4"/>
+                                Transform
                             </button>
+                            @endif
                         </div>
 
                         <div class="flex-col p-4 bg-transparent rounded-tl-none styled-container">
-                            <div x-show="subTab === 'settings'">
+                            {{-- URLs tab --}}
+                            <div x-show="subTab === 'urls'">
                                 <flux:field>
                                     <flux:description>Enter the URL(s) to poll for data:</flux:description>
                                     <flux:textarea
@@ -1195,63 +1279,91 @@ HTML;
                                         {!! 'Hint: Supports multiple requests via line break separation. You can also use configuration variables with <a href="https://help.usetrmnl.com/en/articles/12689499-dynamic-polling-urls">Liquid syntax</a>. ' !!}
                                     </flux:description>
                                 </flux:field>
+
+                                <div class="mt-3">
+                                    <flux:field>
+                                        <flux:description>Preview computed URLs here (readonly):</flux:description>
+                                        <flux:textarea
+                                            readonly
+                                            placeholder="Nothing to show..."
+                                            rows="3"
+                                        >
+                                            {{ $this->parsed_urls }}
+                                        </flux:textarea>
+                                    </flux:field>
+                                </div>
+
+                                <flux:button icon="cloud-arrow-down" wire:click="updateData" class="w-full mt-4">
+                                    Fetch data now
+                                </flux:button>
                             </div>
 
-                            <div x-show="subTab === 'preview'" x-cloak>
-                                <flux:field>
-                                    <flux:description>Preview computed URLs here (readonly):</flux:description>
+                            {{-- Settings tab --}}
+                            <div x-show="subTab === 'settings'" x-cloak>
+                                <div class="mb-4">
+                                    <flux:radio.group wire:model.live="polling_verb" label="Polling Verb" variant="segmented">
+                                        <flux:radio value="get" label="GET"/>
+                                        <flux:radio value="post" label="POST"/>
+                                    </flux:radio.group>
+                                </div>
+
+                                <div class="mb-4">
                                     <flux:textarea
-                                        readonly
-                                        placeholder="Nothing to show..."
-                                        rows="5"
-                                    >
-                                        {{ $this->parsed_urls }}
-                                    </flux:textarea>
-                                </flux:field>
+                                        label="Polling Headers (one per line, format: Header: Value)"
+                                        wire:model="polling_header"
+                                        id="polling_header"
+                                        class="block mt-1 w-full font-mono"
+                                        name="polling_header"
+                                        rows="3"
+                                        placeholder="Authorization: Bearer ey.*******&#10;Content-Type: application/json"
+                                    />
+                                </div>
+
+                                @if($polling_verb === 'post')
+                                <div class="mb-4">
+                                    <flux:textarea
+                                        label="Polling Body (e.g. for GraphQL queries)"
+                                        wire:model="polling_body"
+                                        id="polling_body"
+                                        class="block mt-1 w-full font-mono"
+                                        name="polling_body"
+                                        rows="6"
+                                    />
+                                </div>
+                                @endif
+
+                                <div class="mb-4">
+                                    <flux:input label="Data is stale after minutes" wire:model="data_stale_minutes"
+                                                id="data_stale_minutes"
+                                                class="block mt-1 w-full" type="number" name="data_stale_minutes"/>
+                                </div>
                             </div>
 
-                            <flux:button icon="cloud-arrow-down" wire:click="updateData" class="w-full mt-4">
-                                Fetch data now
-                            </flux:button>
+                            {{-- Transform tab --}}
+                            @if(app(ServerlessTransformService::class)->isEnabled())
+                            <div x-show="subTab === 'transform'" x-cloak>
+                                <div class="mb-4">
+                                    <flux:checkbox
+                                        :checked="$transform_code !== null"
+                                        wire:click="{{ $transform_code === null ? 'enableTransform' : 'disableTransform' }}"
+                                        label="Enable transform"
+                                        description="Run a serverless function to reshape the polled data before rendering."
+                                    />
+                                </div>
+
+                                @if($transform_code !== null)
+                                <div>
+                                    <flux:radio.group wire:model.live="transform_language" label="Language" variant="segmented">
+                                        <flux:radio value="python" label="Python"/>
+                                        <flux:radio value="node" label="Node"/>
+                                        <flux:radio value="php" label="PHP"/>
+                                    </flux:radio.group>
+                                </div>
+                                @endif
+                            </div>
+                            @endif
                         </div>
                     </div>
-
-                        <div class="mb-4">
-                            <flux:radio.group wire:model.live="polling_verb" label="Polling Verb" variant="segmented">
-                                <flux:radio value="get" label="GET"/>
-                                <flux:radio value="post" label="POST"/>
-                            </flux:radio.group>
-                        </div>
-
-                        <div class="mb-4">
-                            <flux:textarea
-                                label="Polling Headers (one per line, format: Header: Value)"
-                                wire:model="polling_header"
-                                id="polling_header"
-                                class="block mt-1 w-full font-mono"
-                                name="polling_header"
-                                rows="3"
-                                placeholder="Authorization: Bearer ey.*******&#10;Content-Type: application/json"
-                            />
-                        </div>
-
-                        @if($polling_verb === 'post')
-                        <div class="mb-4">
-                            <flux:textarea
-                                label="Polling Body (e.g. for GraphQL queries)"
-                                wire:model="polling_body"
-                                id="polling_body"
-                                class="block mt-1 w-full font-mono"
-                                name="polling_body"
-                                rows="6"
-                            />
-                        </div>
-                        @endif
-                        <div class="mb-4">
-                            <flux:input label="Data is stale after minutes" wire:model="data_stale_minutes"
-                                        id="data_stale_minutes"
-                                        class="block mt-1 w-full" type="number" name="data_stale_minutes" autofocus/>
-                        </div>
                     @elseif($data_strategy === 'webhook')
                         <div class="mb-4">
                             <flux:field>
@@ -1341,7 +1453,7 @@ HTML;
         </div>
         <flux:separator class="my-5"/>
         <div>
-            <h3 class="text-xl font-semibold dark:text-gray-100">Markup</h3>
+            <h3 class="text-xl font-semibold dark:text-gray-100">Code</h3>
             @if($plugin->render_markup_view)
                 <div>
                     Edit view
@@ -1401,163 +1513,149 @@ HTML;
             @endif
         </div>
         @if(!$plugin->render_markup_view)
-            <form wire:submit="saveMarkup">
-                <div class="mb-4">
-                    <div>
-                        <div class="flex items-end">
-                            @foreach($active_tabs as $tab)
-                                <button
-                                    type="button"
-                                    wire:click="switchTab('{{ $tab }}')"
-                                    class="tab-button {{ $active_tab === $tab ? 'is-active' : '' }}"
-                                    wire:key="tab-{{ $tab }}"
-                                >
-                                    {{ $this->getLayoutLabel($tab) }}
-                                </button>
-                            @endforeach
+            <div class="mb-4">
+                <div>
+                    <div class="flex items-end">
+                        @foreach($active_tabs as $tab)
+                            <button
+                                type="button"
+                                wire:click="switchTab('{{ $tab }}')"
+                                class="tab-button {{ $active_tab === $tab ? 'is-active' : '' }}"
+                                wire:key="tab-{{ $tab }}"
+                            >
+                                {{ $this->getLayoutLabel($tab) }}
+                            </button>
+                        @endforeach
 
-                            <flux:dropdown>
-                                <flux:button icon="plus" variant="ghost" size="sm" class="m-0.5"></flux:button>
-                                <flux:menu>
-                                    @foreach($this->getAvailableLayouts() as $layout => $label)
-                                        <flux:menu.item wire:click="toggleLayoutTab('{{ $layout }}')">
-                                            <div class="flex items-center gap-2">
-                                                @if(in_array($layout, $active_tabs, true))
-                                                    <flux:icon.check class="size-4" />
-                                                @else
-                                                    <span class="inline-block w-4 h-4"></span>
-                                                @endif
-                                                <span>{{ $label }}</span>
-                                            </div>
-                                        </flux:menu.item>
-                                    @endforeach
-                                </flux:menu>
-                            </flux:dropdown>
-                        </div>
+                        @if($transform_code !== null && app(ServerlessTransformService::class)->isEnabled())
+                            <button
+                                type="button"
+                                wire:click="switchTab('transform')"
+                                class="tab-button {{ $active_tab === 'transform' ? 'is-active' : '' }}"
+                            >
+                                Transform
+                            </button>
+                        @endif
 
-                        <div class="flex-col p-4 bg-transparent rounded-tl-none styled-container">
-                            <flux:field>
-                                @php
-                                    $textareaId = 'code-' . $plugin->id;
-                                @endphp
-                                <flux:label>{{ $markup_language === 'liquid' ? 'Liquid Code' : 'Blade Code' }}</flux:label>
-                                <flux:textarea
-                                    wire:model="markup_code"
-                                    id="{{ $textareaId }}"
-                                    placeholder="Enter your HTML code here..."
-                                    rows="25"
-                                    hidden
-                                />
-                                <div
-                                    x-data="codeEditorFormComponent({
-                                        isDisabled: false,
-                                        language: @js($markup_language === 'liquid' ? 'liquid' : 'html'),
-                                        state: $wire.entangle('markup_code'),
-                                        textareaId: @js($textareaId)
-                                    })"
-                                    wire:ignore
-                                    wire:key="cm-{{ $textareaId }}"
-                                    class="min-h-[300px] h-[300px] overflow-hidden resize-y"
-                                >
-                                    <!-- Loading state -->
-                                    <div x-show="isLoading" class="flex items-center justify-center h-full">
-                                        <div class="flex items-center space-x-2">
-                                            <flux:icon.loading />
+                        <flux:dropdown>
+                            <flux:button icon="plus" variant="ghost" size="sm" class="m-0.5"></flux:button>
+                            <flux:menu>
+                                @foreach($this->getAvailableLayouts() as $layout => $label)
+                                    <flux:menu.item wire:click="toggleLayoutTab('{{ $layout }}')">
+                                        <div class="flex items-center gap-2">
+                                            @if(in_array($layout, $active_tabs, true))
+                                                <flux:icon.check class="size-4" />
+                                            @else
+                                                <span class="inline-block w-4 h-4"></span>
+                                            @endif
+                                            <span>{{ $label }}</span>
                                         </div>
-                                    </div>
-
-                                    <!-- Editor container -->
-                                    <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
-                                </div>
-                            </flux:field>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="flex">
-                    <flux:button type="submit" variant="primary">
-                        Save
-                    </flux:button>
-                </div>
-            </form>
-        @endif
-    </div>
-
-        <flux:separator class="my-5"/>
-        <div>
-            <h3 class="text-xl font-semibold dark:text-gray-100">Transform</h3>
-
-            @if(!app(ServerlessTransformService::class)->isEnabled())
-                <flux:callout class="mt-4" variant="warning" icon="exclamation-circle"
-                    heading="Serverless transforms are disabled."
-                    text="Set TRANSFORM_RUNNER_URL to enable the transform runner." />
-            @elseif($transform_code === null)
-                <div class="mt-4">
-                    <flux:button icon="plus" wire:click="addTransform">Add Transform</flux:button>
-                </div>
-            @else
-                <div class="mt-4">
-                    <div class="flex items-center gap-4 mb-4">
-                        <flux:radio.group wire:model.live="transform_language" label="Language" variant="segmented">
-                            <flux:radio value="python" label="Python"/>
-                            <flux:radio value="node" label="Node"/>
-                            <flux:radio value="php" label="PHP"/>
-                        </flux:radio.group>
+                                    </flux:menu.item>
+                                @endforeach
+                            </flux:menu>
+                        </flux:dropdown>
                     </div>
 
-                    @php $transformTextareaId = 'transform-' . $plugin->id; @endphp
-                    <flux:textarea wire:model="transform_code" id="{{ $transformTextareaId }}" rows="20" hidden/>
-                    <div
-                        x-data="codeEditorFormComponent({
-                            isDisabled: false,
-                            language: @js(match($transform_language) { 'node' => 'javascript', 'php' => 'php', default => 'python' }),
-                            state: $wire.entangle('transform_code'),
-                            textareaId: @js($transformTextareaId)
-                        })"
-                        wire:ignore
-                        wire:key="cm-transform-{{ $plugin->id }}-{{ $transform_language }}"
-                        class="min-h-[300px] h-[300px] overflow-hidden resize-y mb-4"
-                    >
-                        <div x-show="isLoading" class="flex items-center justify-center h-full">
-                            <flux:icon.loading />
-                        </div>
-                        <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
-                    </div>
-
-                    <div class="flex gap-2 mb-4">
-                        <flux:button icon="play" wire:click="runTransform" wire:loading.attr="disabled" wire:target="runTransform">
-                            <span wire:loading.remove wire:target="runTransform">Run</span>
-                            <span wire:loading wire:target="runTransform">Running...</span>
-                        </flux:button>
-                        <flux:button variant="primary" wire:click="saveTransform">Save</flux:button>
-                    </div>
-
-                    @if($transform_run_output !== null)
-                        <div class="mt-2">
-                            <flux:label>Transform Output</flux:label>
-                            @php $outputTextareaId = 'transform-output-' . $plugin->id; @endphp
-                            <flux:textarea wire:model="transform_run_output" id="{{ $outputTextareaId }}" rows="10" hidden/>
+                    <div class="flex-col p-4 bg-transparent rounded-tl-none styled-container">
+                        @if($active_tab === 'transform')
+                            {{-- Transform code editor --}}
+                            @php $transformTextareaId = 'transform-' . $plugin->id; @endphp
+                            <flux:textarea wire:model="transform_code" id="{{ $transformTextareaId }}" rows="20" hidden/>
                             <div
                                 x-data="codeEditorFormComponent({
-                                    isDisabled: true,
-                                    language: 'json',
-                                    state: $wire.entangle('transform_run_output'),
-                                    textareaId: @js($outputTextareaId)
+                                    isDisabled: false,
+                                    language: @js(match($transform_language) { 'node' => 'javascript', 'php' => 'php', default => 'python' }),
+                                    state: $wire.entangle('transform_code'),
+                                    textareaId: @js($transformTextareaId)
                                 })"
                                 wire:ignore
-                                wire:key="cm-{{ $outputTextareaId }}"
-                                class="min-h-[200px] h-[200px] overflow-hidden resize-y"
+                                wire:key="cm-transform-{{ $plugin->id }}-{{ $transform_language }}"
+                                class="min-h-[300px] h-[300px] overflow-hidden resize-y mb-4"
                             >
                                 <div x-show="isLoading" class="flex items-center justify-center h-full">
                                     <flux:icon.loading />
                                 </div>
                                 <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
                             </div>
-                        </div>
-                    @endif
+
+                            @if($transform_run_output !== null)
+                                <div class="mt-2 mb-4">
+                                    <flux:label>Transform Output</flux:label>
+                                    @php $outputTextareaId = 'transform-output-' . $plugin->id; @endphp
+                                    <flux:textarea wire:model="transform_run_output" id="{{ $outputTextareaId }}" rows="10" hidden/>
+                                    <div
+                                        x-data="codeEditorFormComponent({
+                                            isDisabled: true,
+                                            language: 'json',
+                                            state: $wire.entangle('transform_run_output'),
+                                            textareaId: @js($outputTextareaId)
+                                        })"
+                                        wire:ignore
+                                        wire:key="cm-{{ $outputTextareaId }}"
+                                        class="min-h-[200px] h-[200px] overflow-hidden resize-y"
+                                    >
+                                        <div x-show="isLoading" class="flex items-center justify-center h-full">
+                                            <flux:icon.loading />
+                                        </div>
+                                        <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
+                                    </div>
+                                </div>
+                            @endif
+
+                            <div class="flex gap-2">
+                                <flux:button icon="play" wire:click="runTransform" wire:loading.attr="disabled" wire:target="runTransform">
+                                    <span wire:loading.remove wire:target="runTransform">Run</span>
+                                    <span wire:loading wire:target="runTransform">Running...</span>
+                                </flux:button>
+                                <flux:button variant="primary" wire:click="saveTransform">Save</flux:button>
+                            </div>
+                        @else
+                            {{-- Markup code editor --}}
+                            <form wire:submit="saveMarkup">
+                                <flux:field>
+                                    @php
+                                        $textareaId = 'code-' . $plugin->id;
+                                    @endphp
+                                    <flux:label>{{ $markup_language === 'liquid' ? 'Liquid Code' : 'Blade Code' }}</flux:label>
+                                    <flux:textarea
+                                        wire:model="markup_code"
+                                        id="{{ $textareaId }}"
+                                        placeholder="Enter your HTML code here..."
+                                        rows="25"
+                                        hidden
+                                    />
+                                    <div
+                                        x-data="codeEditorFormComponent({
+                                            isDisabled: false,
+                                            language: @js($markup_language === 'liquid' ? 'liquid' : 'html'),
+                                            state: $wire.entangle('markup_code'),
+                                            textareaId: @js($textareaId)
+                                        })"
+                                        wire:ignore
+                                        wire:key="cm-{{ $textareaId }}"
+                                        class="min-h-[300px] h-[300px] overflow-hidden resize-y"
+                                    >
+                                        <div x-show="isLoading" class="flex items-center justify-center h-full">
+                                            <div class="flex items-center space-x-2">
+                                                <flux:icon.loading />
+                                            </div>
+                                        </div>
+                                        <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
+                                    </div>
+                                </flux:field>
+
+                                <div class="flex mt-4">
+                                    <flux:button type="submit" variant="primary">
+                                        Save
+                                    </flux:button>
+                                </div>
+                            </form>
+                        @endif
+                    </div>
                 </div>
-            @endif
-        </div>
+            </div>
+        @endif
+    </div>
     </div>
 </div>
 

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -81,6 +81,8 @@ new class extends Component
 
     public ?string $transform_language = 'python';
 
+    public ?string $transform_error = null;
+
     public bool $is_shared = false;
 
     public function getAvailableUsersProperty(): \Illuminate\Database\Eloquent\Collection
@@ -386,6 +388,12 @@ new class extends Component
                 $this->data_payload = json_encode($this->plugin->data_payload, JSON_PRETTY_PRINT);
                 $this->data_payload_updated_at = $this->plugin->data_payload_updated_at;
 
+                $payload = $this->plugin->data_payload;
+                if ($this->transform_code !== null && is_array($payload) && array_key_exists('error', $payload)) {
+                    $this->transform_error = (string) ($payload['error'] ?? 'Unknown transform error');
+                } else {
+                    $this->transform_error = null;
+                }
             } catch (Exception $e) {
                 $this->dispatch('data-update-error', message: $e->getMessage().$e->getPrevious()?->getMessage());
             }
@@ -1383,6 +1391,9 @@ HTML;
                     @isset($this->data_payload_updated_at)
                         <flux:badge icon="clock" size="sm" variant="pill" class="ml-2">{{ $this->data_payload_updated_at?->diffForHumans() ?? 'Never' }}</flux:badge>
                     @endisset
+                    @if($transform_error !== null)
+                        <flux:badge icon="exclamation-triangle" size="sm" variant="pill" color="red" class="ml-2" :title="$transform_error">Transform error</flux:badge>
+                    @endif
                 </div>
                 <flux:error name="data_payload"/>
                 <flux:field>

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -81,8 +81,6 @@ new class extends Component
 
     public ?string $transform_language = 'python';
 
-    public ?string $transform_run_output = null;
-
     public bool $is_shared = false;
 
     public function getAvailableUsersProperty(): \Illuminate\Database\Eloquent\Collection
@@ -759,7 +757,6 @@ HTML;
     {
         abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
         $this->transform_code = null;
-        $this->transform_run_output = null;
         $this->plugin->update(['transform_code' => null, 'transform_language' => null]);
         if ($this->active_tab === 'transform') {
             $this->active_tab = 'full';
@@ -785,29 +782,6 @@ HTML;
         ]);
 
         Flux::toast(variant: 'success', text: 'Transform saved.');
-    }
-
-    public function runTransform(): void
-    {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
-
-        if (! $this->plugin->data_payload) {
-            $this->dispatch('transform-error', message: 'Fetch data first before running the transform.');
-
-            return;
-        }
-
-        try {
-            $result = app(ServerlessTransformService::class)->run(
-                $this->transform_code ?? '',
-                $this->transform_language ?? 'python',
-                $this->plugin->data_payload,
-                strict: true,
-            );
-            $this->transform_run_output = json_encode($result, JSON_PRETTY_PRINT);
-        } catch (\Throwable $e) {
-            $this->dispatch('transform-error', message: $e->getMessage());
-        }
     }
 
     #[On('config-updated')]
@@ -1578,35 +1552,7 @@ HTML;
                                 <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
                             </div>
 
-                            @if($transform_run_output !== null)
-                                <div class="mt-2 mb-4">
-                                    <flux:label>Transform Output</flux:label>
-                                    @php $outputTextareaId = 'transform-output-' . $plugin->id; @endphp
-                                    <flux:textarea wire:model="transform_run_output" id="{{ $outputTextareaId }}" rows="10" hidden/>
-                                    <div
-                                        x-data="codeEditorFormComponent({
-                                            isDisabled: true,
-                                            language: 'json',
-                                            state: $wire.entangle('transform_run_output'),
-                                            textareaId: @js($outputTextareaId)
-                                        })"
-                                        wire:ignore
-                                        wire:key="cm-{{ $outputTextareaId }}"
-                                        class="min-h-[200px] h-[200px] overflow-hidden resize-y"
-                                    >
-                                        <div x-show="isLoading" class="flex items-center justify-center h-full">
-                                            <flux:icon.loading />
-                                        </div>
-                                        <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
-                                    </div>
-                                </div>
-                            @endif
-
                             <div class="flex gap-2">
-                                <flux:button icon="play" wire:click="runTransform" wire:loading.attr="disabled" wire:target="runTransform">
-                                    <span wire:loading.remove wire:target="runTransform">Run</span>
-                                    <span wire:loading wire:target="runTransform">Running...</span>
-                                </flux:button>
                                 <flux:button variant="primary" wire:click="saveTransform">Save</flux:button>
                             </div>
                         @else
@@ -1784,10 +1730,6 @@ HTML;
 
     $wire.on('data-update-error', ({message}) => {
         alert('Data Update Error: ' + message);
-    });
-
-    $wire.on('transform-error', ({message}) => {
-        alert('Transform Error: ' + message);
     });
 </script>
 @endscript

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -733,6 +733,7 @@ HTML;
                 $this->transform_code ?? '',
                 $this->transform_language ?? 'python',
                 $this->plugin->data_payload,
+                strict: true,
             );
             $this->transform_run_output = json_encode($result, JSON_PRETTY_PRINT);
         } catch (\Throwable $e) {
@@ -1501,7 +1502,7 @@ HTML;
                             textareaId: @js($transformTextareaId)
                         })"
                         wire:ignore
-                        wire:key="cm-{{ $transformTextareaId }}"
+                        wire:key="cm-transform-{{ $plugin->id }}-{{ $transform_language }}"
                         class="min-h-[300px] h-[300px] overflow-hidden resize-y mb-4"
                     >
                         <div x-show="isLoading" class="flex items-center justify-center h-full">

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -1466,9 +1466,6 @@ HTML;
             </form>
         @endif
     </div>
-</div>
-
-
 
         <flux:separator class="my-5"/>
         <div>
@@ -1545,6 +1542,8 @@ HTML;
                 </div>
             @endif
         </div>
+    </div>
+</div>
 
 @script
 <script>

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -3,6 +3,7 @@
 use App\Models\Device;
 use App\Models\DeviceModel;
 use App\Models\Plugin;
+use App\Services\Plugin\ServerlessTransformService;
 use App\Services\PluginExportService;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -74,6 +75,12 @@ new class extends Component
 
     public string $active_tab = 'full';
 
+    public ?string $transform_code = null;
+
+    public ?string $transform_language = 'python';
+
+    public ?string $transform_run_output = null;
+
     public function mount(): void
     {
         abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
@@ -124,6 +131,9 @@ new class extends Component
         // Initialize screen settings from the model
         $this->no_bleed = (bool) ($this->plugin->no_bleed ?? false);
         $this->dark_mode = (bool) ($this->plugin->dark_mode ?? false);
+
+        $this->transform_code = $this->plugin->transform_code;
+        $this->transform_language = $this->plugin->transform_language ?? 'python';
 
         $this->fillformFields();
         $this->data_payload_updated_at = $this->plugin->data_payload_updated_at;
@@ -274,6 +284,8 @@ new class extends Component
         'device_active_until' => 'array',
         'no_bleed' => 'boolean',
         'dark_mode' => 'boolean',
+        'transform_code' => 'nullable|string',
+        'transform_language' => 'nullable|string|in:python,node,php',
     ];
 
     public function editSettings()
@@ -687,6 +699,45 @@ HTML;
         abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
         $this->plugin->delete();
         $this->redirect(route('plugins.index'));
+    }
+
+    public function addTransform(): void
+    {
+        $this->transform_code = '';
+        $this->transform_language = 'python';
+    }
+
+    public function saveTransform(): void
+    {
+        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        $this->validate(['transform_code' => 'nullable|string', 'transform_language' => 'nullable|string|in:python,node,php']);
+
+        $this->plugin->update([
+            'transform_code'     => $this->transform_code ?: null,
+            'transform_language' => $this->transform_code ? $this->transform_language : null,
+        ]);
+    }
+
+    public function runTransform(): void
+    {
+        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+
+        if (! $this->plugin->data_payload) {
+            $this->dispatch('transform-error', message: 'Fetch data first before running the transform.');
+
+            return;
+        }
+
+        try {
+            $result = app(ServerlessTransformService::class)->run(
+                $this->transform_code ?? '',
+                $this->transform_language ?? 'python',
+                $this->plugin->data_payload,
+            );
+            $this->transform_run_output = json_encode($result, JSON_PRETTY_PRINT);
+        } catch (\Throwable $e) {
+            $this->dispatch('transform-error', message: $e->getMessage());
+        }
     }
 
     #[On('config-updated')]
@@ -1418,6 +1469,82 @@ HTML;
 
 
 
+        <flux:separator class="my-5"/>
+        <div>
+            <h3 class="text-xl font-semibold dark:text-gray-100">Transform</h3>
+
+            @if(!app(ServerlessTransformService::class)->isEnabled())
+                <flux:callout class="mt-4" variant="warning" icon="exclamation-circle"
+                    heading="Serverless transforms are disabled."
+                    text="Set TRANSFORM_RUNNER_URL to enable the transform runner." />
+            @elseif($transform_code === null)
+                <div class="mt-4">
+                    <flux:button icon="plus" wire:click="addTransform">Add Transform</flux:button>
+                </div>
+            @else
+                <div class="mt-4">
+                    <div class="flex items-center gap-4 mb-4">
+                        <flux:radio.group wire:model.live="transform_language" label="Language" variant="segmented">
+                            <flux:radio value="python" label="Python"/>
+                            <flux:radio value="node" label="Node"/>
+                            <flux:radio value="php" label="PHP"/>
+                        </flux:radio.group>
+                    </div>
+
+                    @php $transformTextareaId = 'transform-' . $plugin->id; @endphp
+                    <flux:textarea wire:model="transform_code" id="{{ $transformTextareaId }}" rows="20" hidden/>
+                    <div
+                        x-data="codeEditorFormComponent({
+                            isDisabled: false,
+                            language: @js(match($transform_language) { 'node' => 'javascript', 'php' => 'php', default => 'python' }),
+                            state: $wire.entangle('transform_code'),
+                            textareaId: @js($transformTextareaId)
+                        })"
+                        wire:ignore
+                        wire:key="cm-{{ $transformTextareaId }}"
+                        class="min-h-[300px] h-[300px] overflow-hidden resize-y mb-4"
+                    >
+                        <div x-show="isLoading" class="flex items-center justify-center h-full">
+                            <flux:icon.loading />
+                        </div>
+                        <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
+                    </div>
+
+                    <div class="flex gap-2 mb-4">
+                        <flux:button icon="play" wire:click="runTransform" wire:loading.attr="disabled" wire:target="runTransform">
+                            <span wire:loading.remove wire:target="runTransform">Run</span>
+                            <span wire:loading wire:target="runTransform">Running...</span>
+                        </flux:button>
+                        <flux:button variant="primary" wire:click="saveTransform">Save</flux:button>
+                    </div>
+
+                    @if($transform_run_output !== null)
+                        <div class="mt-2">
+                            <flux:label>Transform Output</flux:label>
+                            @php $outputTextareaId = 'transform-output-' . $plugin->id; @endphp
+                            <flux:textarea wire:model="transform_run_output" id="{{ $outputTextareaId }}" rows="10" hidden/>
+                            <div
+                                x-data="codeEditorFormComponent({
+                                    isDisabled: true,
+                                    language: 'json',
+                                    state: $wire.entangle('transform_run_output'),
+                                    textareaId: @js($outputTextareaId)
+                                })"
+                                wire:ignore
+                                wire:key="cm-{{ $outputTextareaId }}"
+                                class="min-h-[200px] h-[200px] overflow-hidden resize-y"
+                            >
+                                <div x-show="isLoading" class="flex items-center justify-center h-full">
+                                    <flux:icon.loading />
+                                </div>
+                                <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
+                            </div>
+                        </div>
+                    @endif
+                </div>
+            @endif
+        </div>
+
 @script
 <script>
     let previewNativeWidth = 800;
@@ -1543,6 +1670,10 @@ HTML;
 
     $wire.on('data-update-error', ({message}) => {
         alert('Data Update Error: ' + message);
+    });
+
+    $wire.on('transform-error', ({message}) => {
+        alert('Transform Error: ' + message);
     });
 </script>
 @endscript

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -538,6 +538,14 @@ HTML;
 
         try {
             $device = $this->createPreviewDevice();
+
+            if ($this->transform_run_output !== null) {
+                $decoded = json_decode($this->transform_run_output, true);
+                if (is_array($decoded)) {
+                    $this->plugin->data_payload = $decoded;
+                }
+            }
+
             $previewMarkup = $this->plugin->render($size, true, $device);
             $dimensions = $this->previewScreenDimensionsForDevice($device);
             $this->dispatch(
@@ -596,6 +604,14 @@ HTML;
 
         try {
             $device = $this->createPreviewDevice();
+
+            if ($this->transform_run_output !== null) {
+                $decoded = json_decode($this->transform_run_output, true);
+                if (is_array($decoded)) {
+                    $this->plugin->data_payload = $decoded;
+                }
+            }
+
             $markup = $this->plugin->render($this->preview_size, true, $device);
 
             $imageUuid = App\Services\ImageGenerationService::generateImageFromModel(

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -15,8 +15,6 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 new class extends Component
 {
-    use \Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-
     public Plugin $plugin;
 
     public ?string $markup_code;
@@ -83,27 +81,9 @@ new class extends Component
 
     public ?string $transform_error = null;
 
-    public bool $is_shared = false;
-
-    public function getAvailableUsersProperty(): \Illuminate\Database\Eloquent\Collection
-    {
-        return \App\Models\User::whereNotNull('confirmed_at')->orderBy('name')->get();
-    }
-
-    public function reassignPlugin(int $newOwnerId): void
-    {
-        $this->authorize('reassign', $this->plugin);
-
-        $newOwner = \App\Models\User::findOrFail($newOwnerId);
-        $this->plugin->update(['user_id' => $newOwner->id]);
-        $this->plugin = $this->plugin->fresh();
-
-        Flux::toast(variant: 'success', text: 'Plugin ownership updated.');
-    }
-
     public function mount(): void
     {
-        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
         $this->blade_code = $this->plugin->render_markup;
         // required to render some stuff
         $this->configuration_template = $this->plugin->configuration_template ?? [];
@@ -177,17 +157,6 @@ new class extends Component
         $this->polling_header = $this->plugin->polling_header;
         $this->polling_body = $this->plugin->polling_body;
         $this->data_payload = json_encode($this->plugin->data_payload, JSON_PRETTY_PRINT);
-        $this->is_shared = (bool) $this->plugin->is_shared;
-    }
-
-    public function toggleShared(): void
-    {
-        $this->authorize('share', $this->plugin);
-
-        $this->plugin->update(['is_shared' => ! $this->plugin->is_shared]);
-        $this->is_shared = (bool) $this->plugin->fresh()->is_shared;
-
-        Flux::toast(variant: 'success', text: $this->is_shared ? 'Plugin shared.' : 'Plugin unshared.');
     }
 
     public function saveMarkup(): void
@@ -750,7 +719,7 @@ HTML;
 
     public function enableTransform(): void
     {
-        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
         if ($this->transform_code === null) {
             $this->transform_code = '';
             $this->transform_language ??= 'python';
@@ -763,7 +732,7 @@ HTML;
 
     public function disableTransform(): void
     {
-        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
         $this->transform_code = null;
         $this->plugin->update(['transform_code' => null, 'transform_language' => null]);
         if ($this->active_tab === 'transform') {
@@ -781,7 +750,7 @@ HTML;
 
     public function saveTransform(): void
     {
-        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
         $this->validate(['transform_code' => 'nullable|string', 'transform_language' => 'nullable|string|in:python,node,php']);
 
         $this->plugin->update([
@@ -842,10 +811,6 @@ HTML;
             </h2>
 
             <div class="flex items-center gap-3">
-                @if($plugin->user_id === auth()->id() || auth()->user()->isAdmin())
-                    <flux:switch wire:click="toggleShared" :checked="$is_shared" label="Shared"/>
-                @endif
-
                 <flux:button.group>
                     <flux:modal.trigger name="preview-plugin">
                         <flux:button icon="eye" wire:click="renderPreview" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Preview</flux:button>
@@ -1112,18 +1077,6 @@ HTML;
                         <flux:input label="Name" wire:model="name" id="name" class="block mt-1 w-full" type="text"
                                     name="name" autofocus/>
                     </div>
-
-                    @if(auth()->user()->isAdmin())
-                        <div class="mb-4">
-                            <flux:select label="Owner" wire:change="reassignPlugin($event.target.value)">
-                                @foreach ($this->availableUsers as $u)
-                                    <flux:select.option value="{{ $u->id }}" :selected="$plugin->user_id === $u->id">
-                                        {{ $u->name }}
-                                    </flux:select.option>
-                                @endforeach
-                            </flux:select>
-                        </div>
-                    @endif
 
                     @php
                         $authorField = null;

--- a/tests/Feature/PluginImportTest.php
+++ b/tests/Feature/PluginImportTest.php
@@ -697,6 +697,22 @@ it('sets both transform fields to null when serverless_language is absent even i
         ->and($plugin->transform_language)->toBeNull();
 });
 
+it('imports transform code from a flat-root ZIP (no src/ prefix, as trmnlp push produces)', function (): void {
+    $user = User::factory()->create();
+    $transformCode = "def run(input):\n    return {'count': len(input.get('data', []))}";
+
+    $zip = makeRootPluginZip([
+        'settings.yml' => "name: Test Plugin\nstrategy: polling\npolling_url: https://example.com\nserverless_language: python\n",
+        'full.liquid'  => '<div>{{ count }}</div>',
+        'transform.py' => $transformCode,
+    ]);
+
+    $plugin = (new PluginImportService())->importFromZip($zip, $user);
+
+    expect($plugin->transform_code)->toBe($transformCode)
+        ->and($plugin->transform_language)->toBe('python');
+});
+
 // Helper methods
 function createMockZipFile(array $files): string
 {
@@ -748,6 +764,19 @@ function makePluginZip(array $srcFiles): UploadedFile
     $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE);
     foreach ($srcFiles as $name => $content) {
         $zip->addFromString('src/'.$name, $content);
+    }
+    $zip->close();
+
+    return new UploadedFile($path, 'plugin.zip', 'application/zip', null, true);
+}
+
+function makeRootPluginZip(array $files): UploadedFile
+{
+    $path = tempnam(sys_get_temp_dir(), 'plugin-test-').'.zip';
+    $zip = new ZipArchive();
+    $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    foreach ($files as $name => $content) {
+        $zip->addFromString($name, $content);
     }
     $zip->close();
 

--- a/tests/Feature/PluginImportTest.php
+++ b/tests/Feature/PluginImportTest.php
@@ -620,6 +620,83 @@ it('imports plugin with only shared.blade.php file', function (): void {
         ->and($plugin->render_markup)->toBeNull();
 });
 
+it('imports transform_code and transform_language from a ZIP with a Python transform', function (): void {
+    $user = User::factory()->create();
+    $transformCode = "def run(input):\n    return {'count': len(input.get('data', []))}";
+
+    $zip = makePluginZip([
+        'settings.yml' => "name: Test Plugin\nstrategy: polling\npolling_url: https://example.com\nserverless_language: python\n",
+        'full.liquid'  => '<div>{{ count }}</div>',
+        'transform.py' => $transformCode,
+    ]);
+
+    $plugin = (new PluginImportService())->importFromZip($zip, $user);
+
+    expect($plugin->transform_code)->toBe($transformCode)
+        ->and($plugin->transform_language)->toBe('python');
+});
+
+it('imports transform_code and transform_language from a ZIP with a Node transform', function (): void {
+    $user = User::factory()->create();
+    $transformCode = 'function run(input) { return { count: input.data.length }; }';
+
+    $zip = makePluginZip([
+        'settings.yml' => "name: Test Plugin\nstrategy: polling\npolling_url: https://example.com\nserverless_language: node\n",
+        'full.liquid'  => '<div>{{ count }}</div>',
+        'transform.js' => $transformCode,
+    ]);
+
+    $plugin = (new PluginImportService())->importFromZip($zip, $user);
+
+    expect($plugin->transform_code)->toBe($transformCode)
+        ->and($plugin->transform_language)->toBe('node');
+});
+
+it('imports transform_code and transform_language from a ZIP with a PHP transform', function (): void {
+    $user = User::factory()->create();
+    $transformCode = '<?php function run($input) { return ["count" => count($input["data"] ?? [])]; }';
+
+    $zip = makePluginZip([
+        'settings.yml'  => "name: Test Plugin\nstrategy: polling\npolling_url: https://example.com\nserverless_language: php\n",
+        'full.liquid'   => '<div>{{ count }}</div>',
+        'transform.php' => $transformCode,
+    ]);
+
+    $plugin = (new PluginImportService())->importFromZip($zip, $user);
+
+    expect($plugin->transform_code)->toBe($transformCode)
+        ->and($plugin->transform_language)->toBe('php');
+});
+
+it('sets both transform fields to null when no transform file is present', function (): void {
+    $user = User::factory()->create();
+
+    $zip = makePluginZip([
+        'settings.yml' => "name: Test Plugin\nstrategy: static\n",
+        'full.liquid'  => '<div>hello</div>',
+    ]);
+
+    $plugin = (new PluginImportService())->importFromZip($zip, $user);
+
+    expect($plugin->transform_code)->toBeNull()
+        ->and($plugin->transform_language)->toBeNull();
+});
+
+it('sets both transform fields to null when serverless_language is absent even if a transform file is present', function (): void {
+    $user = User::factory()->create();
+
+    $zip = makePluginZip([
+        'settings.yml' => "name: Test Plugin\nstrategy: static\n",
+        'full.liquid'  => '<div>hello</div>',
+        'transform.py' => 'def run(input): return input',
+    ]);
+
+    $plugin = (new PluginImportService())->importFromZip($zip, $user);
+
+    expect($plugin->transform_code)->toBeNull()
+        ->and($plugin->transform_language)->toBeNull();
+});
+
 // Helper methods
 function createMockZipFile(array $files): string
 {
@@ -662,4 +739,17 @@ function getValidFullLiquid(): string
   <p>{{ data.description }}</p>
 </div>
 LIQUID;
+}
+
+function makePluginZip(array $srcFiles): UploadedFile
+{
+    $path = tempnam(sys_get_temp_dir(), 'plugin-test-').'.zip';
+    $zip = new ZipArchive();
+    $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    foreach ($srcFiles as $name => $content) {
+        $zip->addFromString('src/'.$name, $content);
+    }
+    $zip->close();
+
+    return new UploadedFile($path, 'plugin.zip', 'application/zip', null, true);
 }

--- a/tests/Unit/Models/PluginTest.php
+++ b/tests/Unit/Models/PluginTest.php
@@ -4,6 +4,7 @@ use App\Models\Playlist;
 use App\Models\PlaylistItem;
 use App\Models\Plugin;
 use App\Models\User;
+use App\Services\Plugin\ServerlessTransformService;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Http;
 
@@ -1079,4 +1080,65 @@ test('deleting plugin cascades mashup playlist items containing plugin id', func
     $secondaryPlugin->delete();
 
     expect(PlaylistItem::query()->find($mashupItem->id))->toBeNull();
+});
+
+test('updateDataPayload pipes polled data through the transform when both transform fields are set', function (): void {
+    Http::fake(['*' => Http::response(['id1', 'id2'], 200, ['Content-Type' => 'application/json'])]);
+
+    $this->mock(ServerlessTransformService::class)
+        ->shouldReceive('run')
+        ->once()
+        ->andReturn(['stories' => [['title' => 'Test Story']]]);
+
+    $plugin = Plugin::factory()->create([
+        'data_strategy'      => 'polling',
+        'polling_url'        => 'https://example.com/api',
+        'polling_verb'       => 'get',
+        'transform_code'     => "def run(input):\n    return {'stories': []}",
+        'transform_language' => 'python',
+    ]);
+
+    $plugin->updateDataPayload();
+
+    expect($plugin->fresh()->data_payload)->toBe(['stories' => [['title' => 'Test Story']]]);
+});
+
+test('updateDataPayload skips the transform when transform_code is null', function (): void {
+    Http::fake(['*' => Http::response(['key' => 'value'], 200, ['Content-Type' => 'application/json'])]);
+
+    $this->mock(ServerlessTransformService::class)
+        ->shouldNotReceive('run');
+
+    $plugin = Plugin::factory()->create([
+        'data_strategy'      => 'polling',
+        'polling_url'        => 'https://example.com/api',
+        'polling_verb'       => 'get',
+        'transform_code'     => null,
+        'transform_language' => null,
+    ]);
+
+    $plugin->updateDataPayload();
+
+    expect($plugin->fresh()->data_payload)->not->toBeNull();
+});
+
+test('updateDataPayload stores raw polled data when the transform service returns it unchanged', function (): void {
+    Http::fake(['*' => Http::response(['raw' => 'data'], 200, ['Content-Type' => 'application/json'])]);
+
+    $this->mock(ServerlessTransformService::class)
+        ->shouldReceive('run')
+        ->once()
+        ->andReturn(['raw' => 'data']);
+
+    $plugin = Plugin::factory()->create([
+        'data_strategy'      => 'polling',
+        'polling_url'        => 'https://example.com/api',
+        'polling_verb'       => 'get',
+        'transform_code'     => 'bad code',
+        'transform_language' => 'php',
+    ]);
+
+    $plugin->updateDataPayload();
+
+    expect($plugin->fresh()->data_payload)->toBe(['raw' => 'data']);
 });

--- a/tests/Unit/Services/ServerlessTransformServiceTest.php
+++ b/tests/Unit/Services/ServerlessTransformServiceTest.php
@@ -23,56 +23,51 @@ it('returns input unchanged when runner URL is not configured', function (): voi
     Http::assertNothingSent();
 });
 
-it('returns input unchanged when runner returns 422', function (): void {
+it('returns error payload when runner returns 422', function (): void {
     config(['services.transform_runner.url' => 'http://runner:3000']);
     Http::fake(['*/run' => Http::response(['error' => 'syntax error'], 422)]);
 
-    $input = ['key' => 'value'];
-    $result = (new ServerlessTransformService())->run('bad code', 'php', $input);
+    $result = (new ServerlessTransformService())->run('bad code', 'php', ['key' => 'value']);
 
-    expect($result)->toBe($input);
+    expect($result)->toHaveKey('error');
 });
 
-it('returns input unchanged when runner returns 500', function (): void {
+it('returns error payload when runner returns 500', function (): void {
     config(['services.transform_runner.url' => 'http://runner:3000']);
     Http::fake(['*/run' => Http::response([], 500)]);
 
-    $input = ['key' => 'value'];
-    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+    $result = (new ServerlessTransformService())->run('...', 'php', ['key' => 'value']);
 
-    expect($result)->toBe($input);
+    expect($result)->toHaveKey('error');
 });
 
-it('returns input unchanged when runner output is not an array', function (): void {
+it('returns runner body when runner output is not an array', function (): void {
     config(['services.transform_runner.url' => 'http://runner:3000']);
     Http::fake(['*/run' => Http::response(['output' => null], 200)]);
 
-    $input = ['key' => 'value'];
-    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+    $result = (new ServerlessTransformService())->run('...', 'php', ['key' => 'value']);
 
-    expect($result)->toBe($input);
+    expect($result)->toBe(['output' => null]);
 });
 
-it('returns input unchanged when connection fails', function (): void {
+it('returns error payload when connection fails', function (): void {
     config(['services.transform_runner.url' => 'http://runner:3000']);
     Http::fake(['*/run' => function () {
         throw new \Illuminate\Http\Client\ConnectionException('Connection refused');
     }]);
 
-    $input = ['key' => 'value'];
-    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+    $result = (new ServerlessTransformService())->run('...', 'php', ['key' => 'value']);
 
-    expect($result)->toBe($input);
+    expect($result)->toHaveKey('error');
 });
 
-it('returns input unchanged when runner returns 400 for unsupported language', function (): void {
+it('returns error payload when runner returns 400 for unsupported language', function (): void {
     config(['services.transform_runner.url' => 'http://runner:3000']);
     Http::fake(['*/run' => Http::response(['error' => 'unsupported language'], 400)]);
 
-    $input = ['key' => 'value'];
-    $result = (new ServerlessTransformService())->run('<?php echo "x";', 'php', $input);
+    $result = (new ServerlessTransformService())->run('<?php echo "x";', 'php', ['key' => 'value']);
 
-    expect($result)->toBe($input);
+    expect($result)->toHaveKey('error');
 });
 
 it('isEnabled returns true when runner URL is configured', function (): void {

--- a/tests/Unit/Services/ServerlessTransformServiceTest.php
+++ b/tests/Unit/Services/ServerlessTransformServiceTest.php
@@ -65,6 +65,16 @@ it('returns input unchanged when connection fails', function (): void {
     expect($result)->toBe($input);
 });
 
+it('returns input unchanged when runner returns 400 for unsupported language', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    Http::fake(['*/run' => Http::response(['error' => 'unsupported language'], 400)]);
+
+    $input = ['key' => 'value'];
+    $result = (new ServerlessTransformService())->run('<?php echo "x";', 'php', $input);
+
+    expect($result)->toBe($input);
+});
+
 it('isEnabled returns true when runner URL is configured', function (): void {
     config(['services.transform_runner.url' => 'http://runner:3000']);
     expect((new ServerlessTransformService())->isEnabled())->toBeTrue();

--- a/tests/Unit/Services/ServerlessTransformServiceTest.php
+++ b/tests/Unit/Services/ServerlessTransformServiceTest.php
@@ -1,95 +1,76 @@
 <?php
 
 use App\Services\Plugin\ServerlessTransformService;
-use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Http;
 
-it('transforms data with a PHP run() function', function (): void {
-    $service = new ServerlessTransformService();
-    $result = $service->run(
-        'function run($input) { return ["doubled" => $input["value"] * 2]; }',
-        'php',
-        ['value' => 5]
-    );
+it('returns transformed output when runner responds with 200', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    Http::fake(['*/run' => Http::response(['output' => ['doubled' => 10]], 200)]);
+
+    $result = (new ServerlessTransformService())->run('...', 'php', ['value' => 5]);
+
     expect($result)->toBe(['doubled' => 10]);
 });
 
-it('strips a leading <?php tag from PHP user code', function (): void {
-    $service = new ServerlessTransformService();
-    $result = $service->run(
-        "<?php\nfunction run(\$input) { return ['ok' => true]; }",
-        'php',
-        []
-    );
-    expect($result)->toBe(['ok' => true]);
-});
+it('returns input unchanged when runner URL is not configured', function (): void {
+    config(['services.transform_runner.url' => null]);
+    Http::fake();
 
-it('falls back to $result variable when run() is not defined (PHP)', function (): void {
-    $service = new ServerlessTransformService();
-    $result = $service->run('$result = ["fallback" => true];', 'php', []);
-    expect($result)->toBe(['fallback' => true]);
-});
-
-it('passes input through unchanged when neither run() nor $result is defined (PHP)', function (): void {
-    $service = new ServerlessTransformService();
     $input = ['key' => 'value'];
-    expect($service->run('// no-op', 'php', $input))->toBe($input);
+    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+
+    expect($result)->toBe($input);
+    Http::assertNothingSent();
 });
 
-it('transforms data with a Node run() function', function (): void {
-    $service = new ServerlessTransformService();
-    $result = $service->run(
-        'function run(input) { return { doubled: input.value * 2 }; }',
-        'node',
-        ['value' => 5]
-    );
-    expect($result)->toBe(['doubled' => 10]);
-});
+it('returns input unchanged when runner returns 422', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    Http::fake(['*/run' => Http::response(['error' => 'syntax error'], 422)]);
 
-it('falls back to result variable when run is not defined (Node)', function (): void {
-    $service = new ServerlessTransformService();
-    $result = $service->run('const result = { fallback: true };', 'node', []);
-    expect($result)->toBe(['fallback' => true]);
-});
-
-it('transforms data with a Python run() function', function (): void {
-    $service = new ServerlessTransformService();
-    $result = $service->run(
-        "def run(input):\n    return {'doubled': input['value'] * 2}",
-        'python',
-        ['value' => 5]
-    );
-    expect($result)->toBe(['doubled' => 10]);
-})->skip(fn () => empty(trim((string) shell_exec('which python3 2>/dev/null'))), 'python3 not on PATH');
-
-it('returns input unchanged for an unsupported language', function (): void {
-    $service = new ServerlessTransformService();
     $input = ['key' => 'value'];
-    expect($service->run('noop', 'cobol', $input))->toBe($input);
-});
+    $result = (new ServerlessTransformService())->run('bad code', 'php', $input);
 
-it('returns input unchanged when the transform exits non-zero', function (): void {
-    Process::fake(['*' => Process::result(output: '', errorOutput: 'fatal error', exitCode: 1)]);
-    $service = new ServerlessTransformService();
-    $input = ['key' => 'value'];
-    expect($service->run('function run($input) { return $input; }', 'php', $input))->toBe($input);
-});
-
-it('returns input unchanged when the transform output is not a JSON object', function (): void {
-    // run() returns null → json_encode(null) = "null" → json_decode → null, not array
-    $service = new ServerlessTransformService();
-    $input = ['key' => 'value'];
-    $result = $service->run('function run($input) { return null; }', 'php', $input);
     expect($result)->toBe($input);
 });
 
-it('returns input unchanged on timeout', function (): void {
-    $service = new ServerlessTransformService();
-    $input = ['value' => 1];
-    $result = $service->run(
-        '<?php function run($input) { sleep(10); return $input; }',
-        'php',
-        $input,
-        1  // 1-second timeout
-    );
+it('returns input unchanged when runner returns 500', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    Http::fake(['*/run' => Http::response([], 500)]);
+
+    $input = ['key' => 'value'];
+    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+
     expect($result)->toBe($input);
+});
+
+it('returns input unchanged when runner output is not an array', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    Http::fake(['*/run' => Http::response(['output' => null], 200)]);
+
+    $input = ['key' => 'value'];
+    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+
+    expect($result)->toBe($input);
+});
+
+it('returns input unchanged when connection fails', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    Http::fake(['*/run' => function () {
+        throw new \Illuminate\Http\Client\ConnectionException('Connection refused');
+    }]);
+
+    $input = ['key' => 'value'];
+    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+
+    expect($result)->toBe($input);
+});
+
+it('isEnabled returns true when runner URL is configured', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    expect((new ServerlessTransformService())->isEnabled())->toBeTrue();
+});
+
+it('isEnabled returns false when runner URL is not configured', function (): void {
+    config(['services.transform_runner.url' => null]);
+    expect((new ServerlessTransformService())->isEnabled())->toBeFalse();
 });

--- a/tests/Unit/Services/ServerlessTransformServiceTest.php
+++ b/tests/Unit/Services/ServerlessTransformServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Services\Plugin\ServerlessTransformService;
+use Illuminate\Support\Facades\Process;
+
+it('transforms data with a PHP run() function', function (): void {
+    $service = new ServerlessTransformService();
+    $result = $service->run(
+        'function run($input) { return ["doubled" => $input["value"] * 2]; }',
+        'php',
+        ['value' => 5]
+    );
+    expect($result)->toBe(['doubled' => 10]);
+});
+
+it('strips a leading <?php tag from PHP user code', function (): void {
+    $service = new ServerlessTransformService();
+    $result = $service->run(
+        "<?php\nfunction run(\$input) { return ['ok' => true]; }",
+        'php',
+        []
+    );
+    expect($result)->toBe(['ok' => true]);
+});
+
+it('falls back to $result variable when run() is not defined (PHP)', function (): void {
+    $service = new ServerlessTransformService();
+    $result = $service->run('$result = ["fallback" => true];', 'php', []);
+    expect($result)->toBe(['fallback' => true]);
+});
+
+it('passes input through unchanged when neither run() nor $result is defined (PHP)', function (): void {
+    $service = new ServerlessTransformService();
+    $input = ['key' => 'value'];
+    expect($service->run('// no-op', 'php', $input))->toBe($input);
+});
+
+it('transforms data with a Node run() function', function (): void {
+    $service = new ServerlessTransformService();
+    $result = $service->run(
+        'function run(input) { return { doubled: input.value * 2 }; }',
+        'node',
+        ['value' => 5]
+    );
+    expect($result)->toBe(['doubled' => 10]);
+});
+
+it('falls back to result variable when run is not defined (Node)', function (): void {
+    $service = new ServerlessTransformService();
+    $result = $service->run('const result = { fallback: true };', 'node', []);
+    expect($result)->toBe(['fallback' => true]);
+});
+
+it('transforms data with a Python run() function', function (): void {
+    $service = new ServerlessTransformService();
+    $result = $service->run(
+        "def run(input):\n    return {'doubled': input['value'] * 2}",
+        'python',
+        ['value' => 5]
+    );
+    expect($result)->toBe(['doubled' => 10]);
+})->skip(fn () => empty(trim((string) shell_exec('which python3 2>/dev/null'))), 'python3 not on PATH');
+
+it('returns input unchanged for an unsupported language', function (): void {
+    $service = new ServerlessTransformService();
+    $input = ['key' => 'value'];
+    expect($service->run('noop', 'cobol', $input))->toBe($input);
+});
+
+it('returns input unchanged when the transform exits non-zero', function (): void {
+    Process::fake(['*' => Process::result(output: '', errorOutput: 'fatal error', exitCode: 1)]);
+    $service = new ServerlessTransformService();
+    $input = ['key' => 'value'];
+    expect($service->run('function run($input) { return $input; }', 'php', $input))->toBe($input);
+});
+
+it('returns input unchanged when the transform output is not a JSON object', function (): void {
+    // run() returns null → json_encode(null) = "null" → json_decode → null, not array
+    $service = new ServerlessTransformService();
+    $input = ['key' => 'value'];
+    $result = $service->run('function run($input) { return null; }', 'php', $input);
+    expect($result)->toBe($input);
+});
+
+it('returns input unchanged on timeout', function (): void {
+    $service = new ServerlessTransformService();
+    $input = ['value' => 1];
+    $result = $service->run(
+        '<?php function run($input) { sleep(10); return $input; }',
+        'php',
+        $input,
+        1  // 1-second timeout
+    );
+    expect($result)->toBe($input);
+});


### PR DESCRIPTION
Serverless transforms can be enabled inside the transform tab

<img width="623" height="856" alt="image" src="https://github.com/user-attachments/assets/c0482da8-c095-4fd7-9e04-63c58d8fd862" />

Then, it can be edited with the templates

<img width="1265" height="611" alt="image" src="https://github.com/user-attachments/assets/00b93cb5-2a0c-4ffc-87c0-891adcaf4a3a" />

or normally uploaded using trmnlp. Code is currently only executed by https://github.com/spark-hpi/larapaper-serverless-runner, so this is something we should talk about. I assume you'd like to have the ability to run code directly on the server?